### PR TITLE
chore: configure formatting

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,2 @@
+profile = default
+version = 0.26.1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ To run all tests, run:
 ```bash
 dune test
 ```
+
+To format files, run:
+
+```bash
+dune fmt
+```


### PR DESCRIPTION
So that we don't need to keep making "run format" commits

I realized today that VS Code won't automatically run format (on save) with that OCaml Platform extension that you installed