### PR TITLE
feat: add lex logic when reading +, -, or = as first char

### DIFF
--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -27,26 +27,56 @@ let rec read_number l t =
 (* First char is +/- *)
 let read_plus_minus l c1 =
   match inc_lex_curr_pos l 1 |> get_char with
-  | '=' -> (string_of_char c1 ^ "=", Token.Assign)
+  | '=' ->
+      let token = string_of_char c1 ^ "=" in
+      (token, Token.Assign token)
   | c2 ->
-      if c1 = c2 then (string_of_char c1 ^ string_of_char c2, Token.Inc_Dec)
-      else (string_of_char c1, Token.Add_Subtract)
+      let token = string_of_char c1 in
+      if c1 = c2 then
+        let token = token ^ string_of_char c2 in
+        (token, Token.Inc_Dec token)
+      else (token, Token.BinOp token)
 
 (* First char is = *)
 let read_equal l =
   match inc_lex_curr_pos l 1 |> get_char with
   | '=' -> (
       match inc_lex_curr_pos l 2 |> get_char with
-      | '=' -> ("===", Token.Equality)
-      | _ -> ("==", Token.Equality))
+      | '=' -> ("===", Token.Equality "===")
+      | _ -> ("==", Token.Equality "=="))
   | '>' -> ("=>", Token.Arrow)
-  | _ -> ("=", Token.Assign)
+  | _ -> ("=", Token.Assign "=")
+
+(* First char is * *)
+let read_star l =
+  match inc_lex_curr_pos l 1 |> get_char with
+  | '*' -> (
+      match inc_lex_curr_pos l 2 |> get_char with
+      | '=' -> ("**=", Token.Assign "**=")
+      | _ -> ("**", Token.BinOp "**"))
+  | '=' -> ("*=", Token.Assign "*=")
+  | _ -> ("*", Token.BinOp "*")
+
+(* First char is % *)
+let read_modulo l =
+  match inc_lex_curr_pos l 1 |> get_char with
+  | '=' -> ("%=", Token.Assign "%=")
+  | _ -> ("%", Token.BinOp "%")
+
+(* First char is / *)
+let read_slash l =
+  match inc_lex_curr_pos l 1 |> get_char with
+  | '=' -> ("/=", Token.Assign "/=")
+  | _ -> ("/", Token.BinOp "/")
 
 let build_token l =
   if l.lex_curr_pos < l.lex_buffer_len then
     match l |> get_char with
     | '+' -> read_plus_minus l '+'
     | '-' -> read_plus_minus l '-'
+    | '*' -> read_star l
+    | '/' -> read_slash l
+    | '%' -> read_modulo l
     | '=' -> read_equal l
     | ';' -> (";", Token.Semi)
     | '0' .. '9' -> read_number l ""
@@ -85,9 +115,9 @@ let show_token = function
   (* Keywords *)
   | Token.Const -> "Const"
   (* Operators *)
-  | Token.Add_Subtract -> "Add_Subtract"
-  | Token.Assign -> "Assign"
-  | Token.Inc_Dec -> "Inc_Dec"
-  | Token.Equality -> "Equality"
+  | Token.BinOp s -> "BinOp " ^ s
+  | Token.Assign s -> "Assign " ^ s
+  | Token.Inc_Dec s -> "Inc_Dec " ^ s
+  | Token.Equality s -> "Equality " ^ s
   (* Delimiters *)
   | Token.Semi -> "Semi"

--- a/lib/token.ml
+++ b/lib/token.ml
@@ -1,12 +1,15 @@
 type t =
   | EOF
+  | Arrow
   (* Literals *)
   | Iden of string
   | Int of int
   (* Keywords *)
   | Const
   (* Operators *)
-  | Add
-  | Equal
+  | Add_Subtract
+  | Assign
+  | Inc_Dec
+  | Equality
   (* Delimiters *)
   | Semi

--- a/lib/token.ml
+++ b/lib/token.ml
@@ -7,9 +7,9 @@ type t =
   (* Keywords *)
   | Const
   (* Operators *)
-  | Add_Subtract
-  | Assign
-  | Inc_Dec
-  | Equality
+  | BinOp of string
+  | Assign of string
+  | Inc_Dec of string
+  | Equality of string
   (* Delimiters *)
   | Semi

--- a/test/test_lexer.ml
+++ b/test/test_lexer.ml
@@ -20,10 +20,35 @@ let next_token_tests =
          make_next_token_test "empty program" "" [ EOF ];
          make_next_token_test "program with whitespace" "   \n\r\t\n" [ EOF ];
          make_next_token_test "basic assignment expression" "const x = 1 + 2;"
-           [ Const; Iden "x"; Equal; Int 1; Add; Int 2; Semi; EOF ];
+           [ Const; Iden "x"; Assign; Int 1; Add_Subtract; Int 2; Semi; EOF ];
+         make_next_token_test "read plus minus" "+ ++ - -- += -= +9 -test"
+           [
+             Add_Subtract;
+             Inc_Dec;
+             Add_Subtract;
+             Inc_Dec;
+             Assign;
+             Assign;
+             Add_Subtract;
+             Int 9;
+             Add_Subtract;
+             Iden "test";
+             EOF;
+           ];
+         make_next_token_test "basic assignment expression" "= == === ==== =>"
+           [ Assign; Equality; Equality; Equality; Assign; Arrow; EOF ];
          make_next_token_test "compact assignment expression"
            "const variable=1+2;"
-           [ Const; Iden "variable"; Equal; Int 1; Add; Int 2; Semi; EOF ];
+           [
+             Const;
+             Iden "variable";
+             Assign;
+             Int 1;
+             Add_Subtract;
+             Int 2;
+             Semi;
+             EOF;
+           ];
        ]
 
 let peek_token_tests =
@@ -39,8 +64,8 @@ let peek_token_tests =
            assert_equal (Iden "x") (Lexer.peek_token l')
              ~printer:Lexer.show_token;
            let l'', _ = Lexer.next_token l' in
-           assert_equal Equal (Lexer.peek_token l'') ~printer:Lexer.show_token;
-           assert_equal Equal (Lexer.peek_token l'') ~printer:Lexer.show_token
+           assert_equal Assign (Lexer.peek_token l'') ~printer:Lexer.show_token;
+           assert_equal Assign (Lexer.peek_token l'') ~printer:Lexer.show_token
          );
        ]
 

--- a/test/test_lexer.ml
+++ b/test/test_lexer.ml
@@ -20,31 +20,51 @@ let next_token_tests =
          make_next_token_test "empty program" "" [ EOF ];
          make_next_token_test "program with whitespace" "   \n\r\t\n" [ EOF ];
          make_next_token_test "basic assignment expression" "const x = 1 + 2;"
-           [ Const; Iden "x"; Assign; Int 1; Add_Subtract; Int 2; Semi; EOF ];
+           [ Const; Iden "x"; Assign "="; Int 1; BinOp "+"; Int 2; Semi; EOF ];
          make_next_token_test "read plus minus" "+ ++ - -- += -= +9 -test"
            [
-             Add_Subtract;
-             Inc_Dec;
-             Add_Subtract;
-             Inc_Dec;
-             Assign;
-             Assign;
-             Add_Subtract;
+             BinOp "+";
+             Inc_Dec "++";
+             BinOp "-";
+             Inc_Dec "--";
+             Assign "+=";
+             Assign "-=";
+             BinOp "+";
              Int 9;
-             Add_Subtract;
+             BinOp "-";
              Iden "test";
              EOF;
            ];
-         make_next_token_test "basic assignment expression" "= == === ==== =>"
-           [ Assign; Equality; Equality; Equality; Assign; Arrow; EOF ];
+         make_next_token_test "Equal Sign Tests" "= == === ==== =>"
+           [
+             Assign "=";
+             Equality "==";
+             Equality "===";
+             Equality "===";
+             Assign "=";
+             Arrow;
+             EOF;
+           ];
+         make_next_token_test "BinOp and Assignment" "* % ** *= **= %= / /="
+           [
+             BinOp "*";
+             BinOp "%";
+             BinOp "**";
+             Assign "*=";
+             Assign "**=";
+             Assign "%=";
+             BinOp "/";
+             Assign "/=";
+             EOF;
+           ];
          make_next_token_test "compact assignment expression"
            "const variable=1+2;"
            [
              Const;
              Iden "variable";
-             Assign;
+             Assign "=";
              Int 1;
-             Add_Subtract;
+             BinOp "+";
              Int 2;
              Semi;
              EOF;
@@ -64,9 +84,10 @@ let peek_token_tests =
            assert_equal (Iden "x") (Lexer.peek_token l')
              ~printer:Lexer.show_token;
            let l'', _ = Lexer.next_token l' in
-           assert_equal Assign (Lexer.peek_token l'') ~printer:Lexer.show_token;
-           assert_equal Assign (Lexer.peek_token l'') ~printer:Lexer.show_token
-         );
+           assert_equal (Assign "=") (Lexer.peek_token l'')
+             ~printer:Lexer.show_token;
+           assert_equal (Assign "=") (Lexer.peek_token l'')
+             ~printer:Lexer.show_token );
        ]
 
 let tests = "lexer test suite" >::: [ next_token_tests; peek_token_tests ]


### PR DESCRIPTION
Handle cases where first character is one of the following:

`+` -> Could be Add_Subtract `+`, Assign `+=`, or Inc_Dec `++`

`-` -> Could be Add_Subtract `-`, Assign `-=`, or Inc_Dec `--`

`=` -> Could be Assign `=`, Arrow `=>`, or Equality `==` or `===`

I updated Token types to be slightly more general, but we can discuss if that's actually beneficial or what we want to do. Also of course let me know if there are other uses for these characters I am not thinking of